### PR TITLE
server: replace autocert with key, certificate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/certs
+/datadir

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/certs
 /datadir
 /dash-client
 /dash-server

--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ docker tag neubot/dash neubot/dash:`git describe --tags --dirty`-`date -u +%Y%m%
 ### Test locally
 
 ```bash
+./mkcerts.bash
 docker run --network=host                    \
+           --volume `pwd`/certs:/certs:ro    \
            --volume `pwd`/datadir:/datadir   \
-           --volume `pwd`/cache:/root/.cache \
            --read-only                       \
            --cap-drop=all                    \
            --cap-add=net_bind_service        \
            neubot/dash                       \
-           -datadir /datadir
+           -datadir /datadir                 \
+           -tls-cert /certs/cert.pem         \
+           -tls-key /certs/key.pem
 ```
 
 ### Release

--- a/README.md
+++ b/README.md
@@ -21,18 +21,30 @@ docker tag neubot/dash neubot/dash:`git describe --tags --dirty`-`date -u +%Y%m%
 ### Test locally
 
 ```bash
-./mkcerts.bash
-docker run --network=host                    \
+rm -f ./certs/*.pem &&                       \
+./mkcerts.bash &&                            \
+sudo chown root:root ./certs/*.pem &&        \
+docker run --network=bridge                  \
+           --publish=80:8888                 \
+           --publish=443:4444                \
+           --publish=9990:9999               \
            --volume `pwd`/certs:/certs:ro    \
            --volume `pwd`/datadir:/datadir   \
            --read-only                       \
            --cap-drop=all                    \
-           --cap-add=net_bind_service        \
            neubot/dash                       \
            -datadir /datadir                 \
+           -http-listen-address :8888        \
+           -https-listen-address :4444       \
+           -prometheusx.listen-address :9999 \
            -tls-cert /certs/cert.pem         \
            -tls-key /certs/key.pem
 ```
+
+This command will run `dash-server` in a container as the root user, with
+no capabilities, limiting access to the file system and exposing all the
+relevant ports: 80 for HTTP based tests, 443 for HTTPS tests, and 9990 to
+access prometheus metrics.
 
 ### Release
 

--- a/mkcerts.bash
+++ b/mkcerts.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+install -d certs
+openssl genrsa -out certs/key.pem
+openssl req -new -x509 -key key.pem -out certs/cert.pem -days 2 \
+  -subj "/C=XX/ST=State/L=Locality/O=Org/OU=Unit/CN=localhost/emailAddress=test@email.address"

--- a/mkcerts.bash
+++ b/mkcerts.bash
@@ -2,5 +2,5 @@
 set -euxo pipefail
 install -d certs
 openssl genrsa -out certs/key.pem
-openssl req -new -x509 -key key.pem -out certs/cert.pem -days 2 \
+openssl req -new -x509 -key certs/key.pem -out certs/cert.pem -days 2          \
   -subj "/C=XX/ST=State/L=Locality/O=Org/OU=Unit/CN=localhost/emailAddress=test@email.address"


### PR DESCRIPTION
This PR contains a set of commits to be squashed where I implement listening for HTTPS connections in the traditional way, i.e. with TLS key and certificate. We determined this is better than autocert.

This means we're not married to `:443` anymore. So, take the chance to make the server listen by default on non-privileged ports and adjust the README to reduce the privileges with which it runs.