### PR TITLE
server/server.go: include datatype in destdir

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -8,8 +8,8 @@ package model
 // of DASH, except ServerURL, added in MK v0.10.6.
 type ClientResults struct {
 	ConnectTime     float64 `json:"connect_time"`
-	DeltaSysTime    float64  `json:"delta_sys_time"`
-	DeltaUserTime   float64  `json:"delta_user_time"`
+	DeltaSysTime    float64 `json:"delta_sys_time"`
+	DeltaUserTime   float64 `json:"delta_user_time"`
 	Elapsed         float64 `json:"elapsed"`
 	ElapsedTarget   int64   `json:"elapsed_target"`
 	InternalAddress string  `json:"internal_address"`

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ type sessionInfo struct {
 	serverSchema model.ServerSchema
 	stamp        time.Time
 }
+
 type dependencies struct {
 	GzipNewWriterLevel func(w io.Writer, level int) (*gzip.Writer, error)
 	IOUtilReadAll      func(r io.Reader) ([]byte, error)
@@ -293,7 +294,7 @@ type resultsFile struct {
 }
 
 func (h *Handler) savedata(session *sessionInfo) error {
-	name := path.Join(h.Datadir, session.stamp.Format("2006/01/02"))
+	name := path.Join(h.Datadir, "dash", session.stamp.Format("2006/01/02"))
 	err := h.deps.OSMkdirAll(name, 0755)
 	if err != nil {
 		h.Logger.Warnf("savedata: os.MkdirAll: %s", err.Error())


### PR DESCRIPTION
While there run `go fmt ./...`.

Closes #20.