### PR TITLE
Resolve several data races in main testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ before_script:
 - go get github.com/mattn/goveralls
 
 script:
-- go test -v -coverprofile=coverage.cov -coverpkg=./... ./...
+- go test -race -v -coverprofile=coverage.cov -coverpkg=./... ./...
 - $GOPATH/bin/goveralls -coverprofile=coverage.cov -service=travis-ci

--- a/cmd/dash-client/main.go
+++ b/cmd/dash-client/main.go
@@ -45,15 +45,9 @@ var (
 	flagScheme = flag.String("scheme", "http", "Scheme to use")
 )
 
-func internalmain() error {
-	log.SetLevel(log.DebugLevel)
-	flag.Parse()
-	ctx, cancel := context.WithTimeout(context.Background(), *flagTimeout)
+func mainWithClientAndTimeout(client *client.Client, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	client := client.New(clientName, clientVersion)
-	client.Logger = log.Log
-	client.FQDN = *flagHostname
-	client.Scheme = *flagScheme
 	ch, err := client.StartDownload(ctx)
 	if err != nil {
 		return err
@@ -74,6 +68,16 @@ func internalmain() error {
 	}
 	fmt.Printf("%s\n", string(data))
 	return nil
+}
+
+func internalmain() error {
+	log.SetLevel(log.DebugLevel)
+	flag.Parse()
+	client := client.New(clientName, clientVersion)
+	client.Logger = log.Log
+	client.FQDN = *flagHostname
+	client.Scheme = *flagScheme
+	return mainWithClientAndTimeout(client, *flagTimeout)
 }
 
 func main() {

--- a/cmd/dash-client/main_test.go
+++ b/cmd/dash-client/main_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/neubot/dash/client"
 	"github.com/neubot/dash/server"
 )
 
@@ -20,22 +21,23 @@ func TestMain(t *testing.T) {
 	mux := http.NewServeMux()
 	handler := server.NewHandler("../../testdata")
 	ctx, cancel := context.WithCancel(context.Background())
+	handler.Logger = log.Log
 	handler.StartReaper(ctx)
 	handler.RegisterHandlers(mux)
-	handler.Logger = log.Log
 	server := httptest.NewServer(mux)
 	defer server.Close()
 	URL, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	*flagHostname = URL.Host
 	var wg sync.WaitGroup
 	for i := 0; i < 17; i++ {
 		wg.Add(1)
 		go func(delay int) {
 			time.Sleep(time.Duration(delay) * time.Second)
-			err = internalmain()
+			client := client.New(clientName, clientVersion)
+			client.FQDN = URL.Host
+			err := mainWithClientAndTimeout(client, 55*time.Second)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/m-lab/go v1.1.0
 	github.com/m-lab/ndt7-client-go v0.0.0-20190724152841-ad7eefc52fe1
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
1. edit the logger variable _before_ using it in the reaper

2. no need to call `main()` in parallel, just call in parallel
a suitable client as suggested in chat by @robertodauria

3. enable race detector when running tests

Closes #26