### PR TITLE
cleanup(server.Handler): hide public fields

### DIFF
--- a/cmd/dash-client/main_test.go
+++ b/cmd/dash-client/main_test.go
@@ -76,9 +76,8 @@ func testhelper(t *testing.T, f func(int, testconfig)) {
 		t.Skip("Skipping this test in short mode")
 	}
 	mux := http.NewServeMux()
-	handler := server.NewHandler("../../testdata")
+	handler := server.NewHandler("../../testdata", log.Log)
 	ctx, cancel := context.WithCancel(context.Background())
-	handler.Logger = log.Log
 	handler.StartReaper(ctx)
 	handler.RegisterHandlers(mux)
 	server := httptest.NewServer(mux)

--- a/cmd/dash-server/main.go
+++ b/cmd/dash-server/main.go
@@ -2,12 +2,12 @@
 //
 // Usage:
 //
-//    dash-server [-datadir <dirpath>]
-//                [-http-listen-address <endpoint>]
-//                [-https-listen-address <endpoint>]
-//                [-prometheusx.listen-address <endpoint>]
-//                [-tls-cert <filepath>]
-//                [-tls-key <filepath>]
+//	dash-server [-datadir <dirpath>]
+//	            [-http-listen-address <endpoint>]
+//	            [-https-listen-address <endpoint>]
+//	            [-prometheusx.listen-address <endpoint>]
+//	            [-tls-cert <filepath>]
+//	            [-tls-key <filepath>]
 //
 // The server will listen for incoming DASH experiment requests and
 // will keep serving them until it is interrupted.
@@ -78,10 +78,9 @@ func main() {
 	promServer := prometheusx.MustServeMetrics()
 	defer promServer.Close()
 	mux := http.NewServeMux()
-	handler := server.NewHandler(*flagDatadir)
+	handler := server.NewHandler(*flagDatadir, log.Log)
 	handler.StartReaper(context.Background())
 	handler.RegisterHandlers(mux)
-	handler.Logger = log.Log
 	rootHandler := handlers.LoggingHandler(os.Stdout, mux)
 	go func() {
 		rtx.Must(http.ListenAndServeTLS(

--- a/server/server.go
+++ b/server/server.go
@@ -60,8 +60,7 @@ type Handler struct {
 	// deps contains the [*Handler] dependencies.
 	deps dependencies
 
-	// logger is the logger to use. This field is initialized by the
-	// NewHandler constructor to a do-nothing logger.
+	// logger is the logger to use.
 	logger model.Logger
 
 	// maxIterations is the maximum allowed number of iterations.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestServerNegotiate(t *testing.T) {
 	t.Run("net.SplitHostPort failure", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		req := new(http.Request)
 		w := httptest.NewRecorder()
 		handler.negotiate(w, req)
@@ -33,7 +33,7 @@ func TestServerNegotiate(t *testing.T) {
 	})
 
 	t.Run("uuid.NewRandom failure", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.deps.UUIDNewRandom = func() (uuid.UUID, error) {
 			return uuid.UUID{}, errors.New("Mocked error")
 		}
@@ -48,7 +48,7 @@ func TestServerNegotiate(t *testing.T) {
 	})
 
 	t.Run("json.Marshal failure", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.deps.JSONMarshal = func(v interface{}) ([]byte, error) {
 			return nil, errors.New("Mocked error")
 		}
@@ -63,7 +63,7 @@ func TestServerNegotiate(t *testing.T) {
 	})
 
 	t.Run("common case", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		req := new(http.Request)
 		req.RemoteAddr = "127.0.0.1:8080"
 		w := httptest.NewRecorder()
@@ -100,7 +100,7 @@ func TestServerNegotiate(t *testing.T) {
 }
 
 func BenchmarkServerGenbody(b *testing.B) {
-	handler := NewHandler("")
+	handler := NewHandler("", log.Log)
 	for i := 0; i < b.N; i++ {
 		count := maxSize
 		handler.genbody(&count)
@@ -109,7 +109,7 @@ func BenchmarkServerGenbody(b *testing.B) {
 
 func TestServerGenbody(t *testing.T) {
 	t.Run("If size is too small", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		count := minSize - 100
 		data, err := handler.genbody(&count)
 		if err != nil {
@@ -121,7 +121,7 @@ func TestServerGenbody(t *testing.T) {
 	})
 
 	t.Run("If size is too large", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		count := maxSize + 100
 		data, err := handler.genbody(&count)
 		if err != nil {
@@ -135,7 +135,7 @@ func TestServerGenbody(t *testing.T) {
 
 func TestServerDownload(t *testing.T) {
 	t.Run("session missing", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		req := new(http.Request)
 		w := httptest.NewRecorder()
 		handler.download(w, req)
@@ -147,7 +147,7 @@ func TestServerDownload(t *testing.T) {
 
 	t.Run("session expired", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		handler.maxIterations = 0
 		req := new(http.Request)
@@ -163,7 +163,7 @@ func TestServerDownload(t *testing.T) {
 
 	t.Run("strcov.Atoi failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.URL = new(url.URL)
@@ -180,7 +180,7 @@ func TestServerDownload(t *testing.T) {
 
 	t.Run("rand.Read failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		handler.deps.RandRead = func(p []byte) (n int, err error) {
 			return 0, errors.New("Mocked error")
@@ -200,7 +200,7 @@ func TestServerDownload(t *testing.T) {
 
 	t.Run("common case", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.URL = new(url.URL)
@@ -226,7 +226,7 @@ func TestServerDownload(t *testing.T) {
 func TestServerSaveData(t *testing.T) {
 	t.Run("os.MkdirAll failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		sessionInfo := handler.popSession(session)
 		handler.deps.OSMkdirAll = func(path string, perm os.FileMode) error {
@@ -240,7 +240,7 @@ func TestServerSaveData(t *testing.T) {
 
 	t.Run("os.OpenFile failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		sessionInfo := handler.popSession(session)
 		handler.deps.OSMkdirAll = func(path string, perm os.FileMode) error {
@@ -259,7 +259,7 @@ func TestServerSaveData(t *testing.T) {
 
 	t.Run("gzip.NewWriterLevel failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		sessionInfo := handler.popSession(session)
 		handler.deps.OSMkdirAll = func(path string, perm os.FileMode) error {
@@ -283,7 +283,7 @@ func TestServerSaveData(t *testing.T) {
 
 	t.Run("json.Marshal failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		sessionInfo := handler.popSession(session)
 		handler.deps.OSMkdirAll = func(path string, perm os.FileMode) error {
@@ -305,7 +305,7 @@ func TestServerSaveData(t *testing.T) {
 
 	t.Run("common case", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		sessionInfo := handler.popSession(session)
 		handler.deps.OSMkdirAll = func(path string, perm os.FileMode) error {
@@ -325,7 +325,7 @@ func TestServerSaveData(t *testing.T) {
 
 func TestServerCollect(t *testing.T) {
 	t.Run("session missing", func(t *testing.T) {
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		req := new(http.Request)
 		w := httptest.NewRecorder()
 		handler.collect(w, req)
@@ -337,7 +337,7 @@ func TestServerCollect(t *testing.T) {
 
 	t.Run("ioutil.ReadAll failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.Header = make(http.Header)
@@ -355,7 +355,7 @@ func TestServerCollect(t *testing.T) {
 
 	t.Run("json.Unmarshal failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.Header = make(http.Header)
@@ -373,7 +373,7 @@ func TestServerCollect(t *testing.T) {
 
 	t.Run("json.Marshal failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.Header = make(http.Header)
@@ -394,7 +394,7 @@ func TestServerCollect(t *testing.T) {
 
 	t.Run("savedata failure", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.Header = make(http.Header)
@@ -418,7 +418,7 @@ func TestServerCollect(t *testing.T) {
 
 	t.Run("common case", func(t *testing.T) {
 		const session = "deadbeef"
-		handler := NewHandler("")
+		handler := NewHandler("", log.Log)
 		handler.createSession(session)
 		req := new(http.Request)
 		req.Header = make(http.Header)
@@ -443,11 +443,10 @@ func TestServerCollect(t *testing.T) {
 
 func TestServerReaper(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping this test in short mode")
+		t.Skip("skipping test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
-	handler := NewHandler("")
-	handler.Logger = log.Log
+	handler := NewHandler("", log.Log)
 	ctx, cancel := context.WithCancel(context.Background())
 	handler.StartReaper(ctx)
 	for i := 0; i < 17; i++ {


### PR DESCRIPTION
We initialize these fields using the constructor and then there's no real need to expose them to any consumer.

While there, fix a log message string.