### PR TITLE
fix(server): use UTC and portable path composition

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -386,7 +386,7 @@ func (h *Handler) savedata(session *sessionInfo) error {
 	}
 
 	// append the file name to the path
-	name = path.Join(name, "/neubot-dash-"+session.stamp.Format("20060102T150405.000000000Z")+".json.gz")
+	name = path.Join(name, "neubot-dash-"+session.stamp.Format("20060102T150405.000000000Z")+".json.gz")
 
 	// open the results file
 	//

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -386,7 +387,7 @@ func (h *Handler) savedata(session *sessionInfo) error {
 	}
 
 	// append the file name to the path
-	name = path.Join(name, "neubot-dash-"+session.stamp.Format("20060102T150405.000000000Z")+".json.gz")
+	name = filepath.Join(name, "neubot-dash-"+session.stamp.Format("20060102T150405.000000000Z")+".json.gz")
 
 	// open the results file
 	//


### PR DESCRIPTION
This diff implements portable path composition theoretically allowing the server to run under Windows systems.

Additionally, this diff implements tests to ensure that we're still composing the output file path correctly.

While there, notice we're not using UTC and enforce UTC.