### PR TITLE
chore: set version to v0.5.0

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ const (
 	libraryName = "neubot-dash"
 
 	// libraryVersion is the version of this library.
-	libraryVersion = "0.4.3"
+	libraryVersion = "0.5.0"
 
 	// magicVersion is a magic number that identifies in a unique
 	// way this implementation of DASH. 0.007xxxyyy is Measurement

--- a/cmd/dash-client/main.go
+++ b/cmd/dash-client/main.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	clientName     = "dash-client-go"
-	clientVersion  = "0.4.3"
+	clientVersion  = "0.5.0"
 	defaultTimeout = 55 * time.Second
 )
 


### PR DESCRIPTION
We need to prepare for the next release. As part of this, we need to bump the version number.